### PR TITLE
Missing loaders in for release (#34)

### DIFF
--- a/configs/webpack.config.prod.js
+++ b/configs/webpack.config.prod.js
@@ -24,6 +24,21 @@ const prodConfig = {
                     fallback: "style-loader",
                     use: ["css-loader", "sass-loader"]
                 })
+            },
+            { test: /\.png$/, loader: "url-loader?limit=100000" },
+            { test: /\.jpg$/, loader: "file-loader" },
+            {
+                test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/,
+                loader: "url-loader?limit=10000&mimetype=application/font-woff"
+            },
+            {
+                test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+                loader: "url-loader?limit=10000&mimetype=application/octet-stream"
+            },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file-loader" },
+            {
+                test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+                loader: "url-loader?limit=10000&mimetype=image/svg+xml"
             }
         ]
     },


### PR DESCRIPTION
I get errors if I do a npm run release
If I understand correctly, there are missing loaders.

ModuleParseError: Module parse failed: Unexpected character '�' (1:0)

Thanks for checking!